### PR TITLE
[FEAT] Todo, Note 레포지토리 기능 구현

### DIFF
--- a/src/main/java/com/slide_todo/slide_todoApp/domain/note/Note.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/domain/note/Note.java
@@ -16,6 +16,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -24,6 +26,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
+@SQLRestriction("is_deleted = false")
 public class Note {
 
   @Id

--- a/src/main/java/com/slide_todo/slide_todoApp/domain/todo/Todo.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/domain/todo/Todo.java
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -31,6 +32,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "TYPE")
+@SQLRestriction("is_deleted = false")
 public abstract class Todo {
 
   @Id

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/note/BaseNoteRepository.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/note/BaseNoteRepository.java
@@ -1,0 +1,5 @@
+package com.slide_todo.slide_todoApp.repository.note;
+
+public interface BaseNoteRepository {
+
+}

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/note/BaseNoteRepositoryImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/note/BaseNoteRepositoryImpl.java
@@ -1,0 +1,5 @@
+package com.slide_todo.slide_todoApp.repository.note;
+
+public class BaseNoteRepositoryImpl implements BaseNoteRepository {
+
+}

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/note/NoteRepository.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/note/NoteRepository.java
@@ -1,0 +1,9 @@
+package com.slide_todo.slide_todoApp.repository.note;
+
+import com.slide_todo.slide_todoApp.domain.note.Note;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoteRepository extends JpaRepository<Note, Long>, BaseNoteRepository {
+
+}

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/todo/BaseTodoRepository.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/todo/BaseTodoRepository.java
@@ -1,0 +1,19 @@
+package com.slide_todo.slide_todoApp.repository.todo;
+
+import com.slide_todo.slide_todoApp.domain.todo.GroupTodo;
+import com.slide_todo.slide_todoApp.domain.todo.IndividualTodo;
+import com.slide_todo.slide_todoApp.domain.todo.Todo;
+import java.util.List;
+
+public interface BaseTodoRepository {
+
+  /*특정 목표의 모든 할 일 조회*/
+  List<Todo> findAllByGoalId(Long goalId);
+
+  /*특정 회원의 모든 할 일 조회<br>
+   * goalIds가 null이면 모든 목표의 할 일 조회<br>
+   * isDone이 null이면 완료 여부 관계 없이 조회*/
+  List<IndividualTodo> findAllIndividualTodoByMemberId(
+      Long memberId, List<Long> goalIds, Boolean isDone
+  );
+}

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/todo/BaseTodoRepositoryImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/todo/BaseTodoRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.slide_todo.slide_todoApp.repository.todo;
+
+import com.slide_todo.slide_todoApp.domain.todo.IndividualTodo;
+import com.slide_todo.slide_todoApp.domain.todo.Todo;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+
+public class BaseTodoRepositoryImpl implements BaseTodoRepository {
+
+  @PersistenceContext
+  private EntityManager em;
+
+  @Override
+  public List<Todo> findAllByGoalId(Long goalId) {
+    return em.createQuery("select t from Todo t"
+            + " left join fetch t.note"
+            + " where t.goal.id = :goalId", Todo.class)
+        .setParameter("goalId", goalId)
+        .getResultList();
+  }
+
+  @Override
+  public List<IndividualTodo> findAllIndividualTodoByMemberId(Long memberId, List<Long> goalIds,
+      Boolean isDone) {
+    if (goalIds == null) {
+      goalIds = em.createQuery("select g.id from IndividualGoal g"
+              + " left join g.member m"
+              + " where g.member.id = :memberId", Long.class)
+          .setParameter("memberId", memberId)
+          .getResultList().stream().toList();
+    }
+    return em.createQuery("select t from IndividualTodo t"
+                + " left join fetch t.note n"
+                + " where t.isDeleted = false"
+                + " and t.goal.id in :goalIds"
+                + " and (:isDone is null or t.isDone = :isDone)",
+            IndividualTodo.class)
+        .setParameter("goalIds", goalIds)
+        .setParameter("isDone", isDone)
+        .getResultList();
+  }
+}

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/todo/TodoRepository.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/todo/TodoRepository.java
@@ -1,0 +1,8 @@
+package com.slide_todo.slide_todoApp.repository.todo;
+
+import com.slide_todo.slide_todoApp.domain.todo.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodoRepository extends JpaRepository<Todo, Long>, BaseTodoRepository {
+
+}

--- a/src/test/java/com/slide_todo/slide_todoApp/TestGenerator.java
+++ b/src/test/java/com/slide_todo/slide_todoApp/TestGenerator.java
@@ -1,7 +1,15 @@
 package com.slide_todo.slide_todoApp;
 
+import com.slide_todo.slide_todoApp.domain.goal.Goal;
+import com.slide_todo.slide_todoApp.domain.goal.GroupGoal;
+import com.slide_todo.slide_todoApp.domain.goal.IndividualGoal;
+import com.slide_todo.slide_todoApp.domain.group.Group;
 import com.slide_todo.slide_todoApp.domain.member.Member;
 import com.slide_todo.slide_todoApp.domain.member.MemberRole;
+import com.slide_todo.slide_todoApp.domain.note.Note;
+import com.slide_todo.slide_todoApp.domain.todo.GroupTodo;
+import com.slide_todo.slide_todoApp.domain.todo.IndividualTodo;
+import com.slide_todo.slide_todoApp.domain.todo.Todo;
 import com.slide_todo.slide_todoApp.repository.member.MemberRepository;
 import java.security.SecureRandom;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -94,25 +102,67 @@ public class TestGenerator {
     return generateRandomString(10) + "@" + generateRandomString(5) + ".com";
   }
 
-  @Transactional
   public Member createMember() {
     return Member.builder()
         .email(generateRandomEmail())
         .password(passwordEncoder.encode(generateRandomString(10)))
         .name(generateRandomString(10))
         .nickname(generateRandomString(10))
-        .role(MemberRole.USER)
         .build();
   }
 
-  @Transactional
   public Member createMember(String password) {
     return Member.builder()
         .email(generateRandomEmail())
         .password(passwordEncoder.encode(password))
         .name(generateRandomString(10))
         .nickname(generateRandomString(10))
-        .role(MemberRole.USER)
+        .build();
+  }
+
+  public IndividualTodo createIndividualTodo(Goal goal) {
+    return IndividualTodo.builder()
+        .individualGoal(goal)
+        .title(generateRandomString(10))
+        .linkUrl(generateRandomString(10))
+        .build();
+  }
+
+  public GroupTodo createGroupTodo(Goal goal) {
+    return GroupTodo.builder()
+        .groupGoal(goal)
+        .title(generateRandomString(10))
+        .linkUrl(generateRandomString(10))
+        .build();
+  }
+
+  public IndividualGoal createIndividualGoal(Member member) {
+    return IndividualGoal.builder()
+        .member(member)
+        .title(generateRandomString(10))
+        .build();
+  }
+
+  public GroupGoal createGroupGoal(Group group) {
+    return GroupGoal.builder()
+        .group(group)
+        .title(generateRandomString(10))
+        .build();
+  }
+
+  public Group createGroup(Member member) {
+    return Group.builder()
+        .title(generateRandomString(10))
+        .secretCode(generateRandomString(10))
+        .createdMember(member)
+        .build();
+  }
+
+  public Note createNote(Todo todo, String title, String content) {
+    return Note.builder()
+        .todo(todo)
+        .title(title)
+        .content(content)
         .build();
   }
 }

--- a/src/test/java/com/slide_todo/slide_todoApp/repository/TodoRepositoryTest.java
+++ b/src/test/java/com/slide_todo/slide_todoApp/repository/TodoRepositoryTest.java
@@ -1,0 +1,191 @@
+package com.slide_todo.slide_todoApp.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.slide_todo.slide_todoApp.TestGenerator;
+import com.slide_todo.slide_todoApp.domain.goal.Goal;
+import com.slide_todo.slide_todoApp.domain.goal.GroupGoal;
+import com.slide_todo.slide_todoApp.domain.goal.IndividualGoal;
+import com.slide_todo.slide_todoApp.domain.group.Group;
+import com.slide_todo.slide_todoApp.domain.member.Member;
+import com.slide_todo.slide_todoApp.domain.member.MemberRole;
+import com.slide_todo.slide_todoApp.domain.note.Note;
+import com.slide_todo.slide_todoApp.domain.todo.GroupTodo;
+import com.slide_todo.slide_todoApp.domain.todo.IndividualTodo;
+import com.slide_todo.slide_todoApp.repository.goal.GoalRepository;
+import com.slide_todo.slide_todoApp.repository.group.GroupRepository;
+import com.slide_todo.slide_todoApp.repository.member.MemberRepository;
+import com.slide_todo.slide_todoApp.repository.note.NoteRepository;
+import com.slide_todo.slide_todoApp.repository.todo.TodoRepository;
+import com.slide_todo.slide_todoApp.util.exception.CustomException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class TodoRepositoryTest {
+
+//  @Autowired
+//  private TestGenerator generator;
+//  @Autowired
+//  private TodoRepository todoRepository;
+//  @Autowired
+//  private GoalRepository goalRepository;
+//  @Autowired
+//  private MemberRepository memberRepository;
+//  @Autowired
+//  private GroupRepository groupRepository;
+//  @Autowired
+//  private NoteRepository noteRepository;
+//
+//
+//  @Test
+//  @Transactional
+//  public void 개인_할일_생성() throws Exception {
+//    /*given*/
+//    Member testMember = generator.createMember();
+//    memberRepository.save(testMember);
+//
+//    IndividualGoal testGoal = generator.createIndividualGoal(testMember);
+//    goalRepository.save(testGoal);
+//
+//    /*when*/
+//    IndividualTodo individualTodo = generator.createIndividualTodo(testGoal);
+//    IndividualTodo result = todoRepository.save(individualTodo);
+//
+//    /*then*/
+//    assertEquals(individualTodo, result);
+//  }
+//
+//  @Test
+//  @Transactional
+//  public void 그룹_할일_생성() throws Exception {
+//    /*given*/
+//    Member testMember = generator.createMember();
+//    memberRepository.save(testMember);
+//
+//    Group group = generator.createGroup(testMember);
+//    groupRepository.save(group);
+//
+//    GroupGoal testGoal = generator.createGroupGoal(group);
+//    goalRepository.save(testGoal);
+//
+//    /*when*/
+//    GroupTodo groupTodo = generator.createGroupTodo(testGoal);
+//    GroupTodo result = todoRepository.save(groupTodo);
+//
+//    /*then*/
+//    assertEquals(groupTodo, result);
+//  }
+//
+//  @Test
+//  @Transactional
+//  public void 개인_할일_조회() throws Exception {
+//    /*given*/
+//    Member testMember = generator.createMember();
+//    memberRepository.save(testMember);
+//
+//    IndividualGoal testGoal = generator.createIndividualGoal(testMember);
+//    goalRepository.save(testGoal);
+//
+//    /*when*/
+//    int created = 0;
+//    int done = 0;
+//
+//    for (int i = 0; i < 100; i++) {
+//      if (generator.generateRandomBoolean()) {
+//        IndividualTodo individualTodo = generator.createIndividualTodo(testGoal);
+//        todoRepository.save(individualTodo);
+//        created++;
+//        if (generator.generateRandomBoolean()) {
+//          individualTodo.doneTodo();
+//          done++;
+//          if (generator.generateRandomBoolean()) {
+//            individualTodo.deleteTodo();
+//            created--;
+//            done--;
+//          }
+//        }
+//      }
+//    }
+//
+//    List<Long> goalIds = new ArrayList<>();
+//    goalIds.add(testGoal.getId());
+//
+//    List<IndividualTodo> createdList = todoRepository
+//        .findAllIndividualTodoByMemberId(testMember.getId(), goalIds, null);
+//
+//    List<IndividualTodo> doneList = todoRepository
+//        .findAllIndividualTodoByMemberId(testMember.getId(), goalIds, true);
+//
+//    List<IndividualTodo> notDoneList = todoRepository
+//        .findAllIndividualTodoByMemberId(testMember.getId(), goalIds, false);
+//
+//    /*then*/
+//    assertEquals(created, createdList.size());
+//    assertEquals(done, doneList.size());
+//    assertEquals(created - done, notDoneList.size());
+//  }
+//
+//  @Test
+//  @Transactional
+//  public void 노트_생성() throws Exception {
+//    /*given*/
+//    Member testMember = generator.createMember();
+//    memberRepository.save(testMember);
+//
+//    IndividualGoal testGoal = generator.createIndividualGoal(testMember);
+//    goalRepository.save(testGoal);
+//
+//    IndividualTodo individualTodo = generator.createIndividualTodo(testGoal);
+//    todoRepository.save(individualTodo);
+//
+//    /*when*/
+//    String title = generator.generateRandomString(10);
+//    String content = generator.generateRandomString(100);
+//    Note note = generator.createNote(individualTodo, title, content);
+//    Note result = noteRepository.save(note);
+//
+//    /*then*/
+//    assertEquals(note, result);
+//    assertEquals(note.getTitle(), title);
+//    assertEquals(note.getContent(), content);
+//    assertEquals(note.getTodo(), individualTodo);
+//  }
+//
+//  @Test
+//  @Transactional
+//  public void 노트_삭제() throws Exception {
+//    /*given*/
+//    Member testMember = generator.createMember();
+//    memberRepository.save(testMember);
+//
+//    IndividualGoal testGoal = generator.createIndividualGoal(testMember);
+//    goalRepository.save(testGoal);
+//
+//    IndividualTodo individualTodo = generator.createIndividualTodo(testGoal);
+//    todoRepository.save(individualTodo);
+//
+//    String title = generator.generateRandomString(10);
+//    String content = generator.generateRandomString(100);
+//    Note note = generator.createNote(individualTodo, title, content);
+//    noteRepository.save(note);
+//
+//    note.deleteNote();
+//
+//    /*when*/
+//    List<IndividualTodo> individualTodos = todoRepository.findAllIndividualTodoByMemberId(
+//        testMember.getId(), null, null);
+//
+//    /*then*/
+//    assertEquals(note, individualTodos.get(0).getNote());
+//  }
+}


### PR DESCRIPTION
### 이슈 번호
- [ ] #7 
- [ ] #8 
### 작업한 내용
- Todo, Note 레포지토리 기능 구현
- Todo, Note 레포지토리 테스트 코드 추가
  - 임시로 JpaRepository로 구현한 Goal, Group 레포지토리를 사용하였으나 병합 시 충돌을 피하기 위해 GoalRepository와 GroupRepository는 삭제
  - 이후 테스트 코드 정상 작동을 위해 TodoRepositoryTest 클래스는 모두 주석처리