### PR TITLE
[FEAT] GroupGoal 엔티티에 groupMember 필드 추가

### DIFF
--- a/src/main/java/com/slide_todo/slide_todoApp/controller/AdminGoalController.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/controller/AdminGoalController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "어드민 목표 관리 API")
 @RequestMapping("/admin/goals")
 @RequiredArgsConstructor
 public class AdminGoalController {
@@ -66,6 +68,7 @@ public class AdminGoalController {
       HttpServletRequest request,
       @Parameter(description = "검색할 페이지 번호") @RequestParam long page,
       @Parameter(description = "한 페이지에 검색할 데이터 수") @RequestParam long limit,
+      @Parameter(description = "검색할 닉네임 조건") @RequestParam(required = false) String nickname,
       @Parameter(description = "검색할 그룹 이름 조건") @RequestParam(name = "group_name", required = false) String groupName,
       @Parameter(description = "검색할 목표 제목 조건") @RequestParam(required = false) String title,
       @Parameter(description = "검색할 목표 생성일 조건(~이후)")
@@ -74,7 +77,7 @@ public class AdminGoalController {
       @RequestParam(name = "created_before", required = false) String createdBefore
   ) {
     Long adminId = jwtProvider.getAdminMemberId(request);
-    return adminGoalService.getGroupGoalsByAdmin(page, limit, groupName, title, createdAfter,
+    return adminGoalService.getGroupGoalsByAdmin(page, limit, nickname, groupName, title, createdAfter,
         createdBefore);
   }
 
@@ -115,6 +118,7 @@ public class AdminGoalController {
       HttpServletRequest request,
       @Parameter(description = "검색할 페이지 번호") @RequestParam long page,
       @Parameter(description = "한 페이지에 검색할 데이터 수") @RequestParam long limit,
+      @Parameter(description = "검색할 닉네임 조건") @RequestParam(required = false) String nickname,
       @Parameter(description = "검색할 닉네임 조건") @RequestParam(name = "group_name", required = false) String groupName,
       @Parameter(description = "검색할 목표 제목 조건") @RequestParam(required = false) String title,
       @Parameter(description = "검색할 목표 생성일 조건(~이후)")
@@ -124,7 +128,7 @@ public class AdminGoalController {
       @RequestBody GoalIdsDTO goalIds
   ) {
     Long adminId = jwtProvider.getAdminMemberId(request);
-    return adminGoalService.deleteGroupGoalsByAdmin(page, limit, groupName, title, createdAfter,
+    return adminGoalService.deleteGroupGoalsByAdmin(page, limit, nickname, groupName, title, createdAfter,
         createdBefore, goalIds);
   }
 

--- a/src/main/java/com/slide_todo/slide_todoApp/controller/AdminMemberController.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/controller/AdminMemberController.java
@@ -1,9 +1,9 @@
 package com.slide_todo.slide_todoApp.controller;
 
-import com.slide_todo.slide_todoApp.dto.member.MemberDetailDTO;
+import com.slide_todo.slide_todoApp.dto.member.admin.AdminMemberDetailDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberIdsDTO;
-import com.slide_todo.slide_todoApp.dto.member.MemberListDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberUpdateDTO;
+import com.slide_todo.slide_todoApp.dto.member.admin.AdminMemberListDTO;
 import com.slide_todo.slide_todoApp.service.member.AdminMemberService;
 import com.slide_todo.slide_todoApp.util.jwt.JwtProvider;
 import com.slide_todo.slide_todoApp.util.response.ResponseDTO;
@@ -34,7 +34,7 @@ public class AdminMemberController {
   @GetMapping("")
   @Operation(summary = "어드민 페이지에서 유저 리스트 조회", description = "유저 리스트를 조회합니다.")
   @ApiResponse(responseCode = "200", description = "유저 리스트 조회 성공")
-  public ResponseDTO<MemberListDTO> getAllMembers(
+  public ResponseDTO<AdminMemberListDTO> getAllMembers(
       HttpServletRequest request,
       @Parameter(description = "검색할 페이지 번호") @RequestParam long page,
       @Parameter(description = "한 페이지에 검색할 데이터 수") @RequestParam long limit,
@@ -51,7 +51,7 @@ public class AdminMemberController {
   @GetMapping("/detail/{member_id}")
   @Operation(summary = "어드민 페이지에서 유저 상세정보 조회", description = "유저 상세정보를 조회합니다.")
   @ApiResponse(responseCode = "200", description = "유저 상세정보 조회 성공")
-  public ResponseDTO<MemberDetailDTO> getMemberDetailInformation(
+  public ResponseDTO<AdminMemberDetailDTO> getMemberDetailInformation(
       HttpServletRequest request,
       @PathVariable(name = "member_id") Long memberId
   ) {
@@ -63,7 +63,7 @@ public class AdminMemberController {
   @DeleteMapping("/delete")
   @Operation(summary = "복수 유저 삭제", description = "복수 유저를 삭제합니다.")
   @ApiResponse(responseCode = "200", description = "복수 유저 삭제 성공")
-  public ResponseDTO<MemberListDTO> deleteMembers(
+  public ResponseDTO<AdminMemberListDTO> deleteMembers(
       HttpServletRequest request,
       @Parameter(description = "검색할 페이지 번호") @RequestParam long page,
       @Parameter(description = "한 페이지에 검색할 데이터 수") @RequestParam long limit,
@@ -81,7 +81,7 @@ public class AdminMemberController {
   @PatchMapping("/update/{member_id}")
   @Operation(summary = "유저 데이터 수정", description = "유저 데이터를 수정합니다.")
   @ApiResponse(responseCode = "200", description = "유저 데이터 수정 성공")
-  public ResponseDTO<MemberDetailDTO> updateMemberInformation(
+  public ResponseDTO<AdminMemberDetailDTO> updateMemberInformation(
       HttpServletRequest request,
       @PathVariable(name = "member_id") Long memberId,
       @RequestBody MemberUpdateDTO memberUpdateDTO

--- a/src/main/java/com/slide_todo/slide_todoApp/controller/GroupGoalController.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/controller/GroupGoalController.java
@@ -6,9 +6,12 @@ import com.slide_todo.slide_todoApp.dto.goal.GoalTodosResponseDTO;
 import com.slide_todo.slide_todoApp.dto.goal.GroupGoalDTO;
 import com.slide_todo.slide_todoApp.dto.goal.GroupGoalTodoDTO;
 import com.slide_todo.slide_todoApp.service.goal.GroupGoalService;
+import com.slide_todo.slide_todoApp.util.jwt.JwtProvider;
 import com.slide_todo.slide_todoApp.util.response.ResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,16 +19,23 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "그룹 목표 API")
 public class GroupGoalController {
     private final GroupGoalService groupGoalService;
+    private final JwtProvider jwtProvider;
 
-    public GroupGoalController(GroupGoalService groupGoalService) {
+    public GroupGoalController(GroupGoalService groupGoalService,
+        JwtProvider jwtProvider) {
         this.groupGoalService = groupGoalService;
+        this.jwtProvider = jwtProvider;
     }
 
     @PostMapping("/{groupId}")
     @Operation(summary = "그룹 목표 생성")
-    public ResponseDTO<GroupGoalDTO> createGroupGoal(@PathVariable Long groupId, @RequestBody GoalTitleDTO goalTitleDTO){
+    public ResponseDTO<GroupGoalDTO> createGroupGoal(
+        HttpServletRequest request,
+        @PathVariable Long groupId,
+        @RequestBody GoalTitleDTO goalTitleDTO){
+        Long memberId = jwtProvider.getMemberId(request);
         String title = goalTitleDTO.getTitle();
-        return groupGoalService.createGroupGoal(groupId, title);
+        return groupGoalService.createGroupGoal(memberId, groupId, title);
     }
 
     @GetMapping("/{groupId}")

--- a/src/main/java/com/slide_todo/slide_todoApp/domain/goal/GroupGoal.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/domain/goal/GroupGoal.java
@@ -1,6 +1,7 @@
 package com.slide_todo.slide_todoApp.domain.goal;
 
 import com.slide_todo.slide_todoApp.domain.group.Group;
+import com.slide_todo.slide_todoApp.domain.group.GroupMember;
 import com.slide_todo.slide_todoApp.domain.todo.GroupTodo;
 import jakarta.persistence.*;
 import java.util.ArrayList;
@@ -17,10 +18,15 @@ public class GroupGoal extends Goal {
     @JoinColumn(name = "group_id")
     private Group group;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_member_id")
+    private GroupMember groupMember;
+
     @Builder
-    public GroupGoal(String title, Group group) {
+    public GroupGoal(String title, Group group, GroupMember groupMember) {
         super(title);
         this.group = group;
+        this.groupMember = groupMember;
     }
 
     public GroupGoal() {

--- a/src/main/java/com/slide_todo/slide_todoApp/domain/note/Note.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/domain/note/Note.java
@@ -69,6 +69,11 @@ public class Note {
     this.todo.writeNote(this);
   }
 
+  /**
+   * 할 일의 노트를 수정
+   * @param title
+   * @param content
+   */
   public void updateNote(String title, String content) {
     if (title != null) {
       this.title = title;
@@ -79,7 +84,11 @@ public class Note {
     this.updatedAt = LocalDateTime.now();
   }
 
+  /**
+   * 할 일의 노트를 삭제
+   */
   public void deleteNote() {
+    this.getTodo().deleteNote();
     this.isDeleted = true;
     this.updatedAt = LocalDateTime.now();
   }

--- a/src/main/java/com/slide_todo/slide_todoApp/domain/todo/Todo.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/domain/todo/Todo.java
@@ -96,6 +96,7 @@ public abstract class Todo {
     if (this.note != null) {
       this.note.deleteNote();
     }
+    this.getGoal().getTodos().remove(this);
     this.updatedAt = LocalDateTime.now();
   }
 
@@ -121,9 +122,17 @@ public abstract class Todo {
 
   /**
    * 할 일의 완료 여부를 확인
+   *
    * @return
    */
   public Boolean checkDone() {
     return this.isDone;
-  };
+  }
+
+  /**
+   * 할 일의 노트를 삭제
+   */
+  public void deleteNote() {
+    this.note = null;
+  }
 }

--- a/src/main/java/com/slide_todo/slide_todoApp/dto/goal/admin/GroupGoalAdminDTO.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/dto/goal/admin/GroupGoalAdminDTO.java
@@ -3,6 +3,7 @@ package com.slide_todo.slide_todoApp.dto.goal.admin;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.slide_todo.slide_todoApp.domain.goal.GroupGoal;
 import com.slide_todo.slide_todoApp.domain.group.Group;
+import com.slide_todo.slide_todoApp.domain.group.GroupMember;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,6 +33,8 @@ public class GroupGoalAdminDTO {
     private GroupInGoalDTO groupInGoalDTO;
     private Long id;
     private String title;
+    @JsonProperty("member")
+    private GroupMemberInGroupGoalDTO member;
     @JsonProperty("progress_rate")
     private BigDecimal progressRate;
     @JsonProperty("created_at")
@@ -43,8 +46,27 @@ public class GroupGoalAdminDTO {
       this.groupInGoalDTO = new GroupInGoalDTO(goal.getGroup());
       this.id = goal.getId();
       this.title = goal.getTitle();
+      if (goal.getGroupMember() != null) {
+        this.member = new GroupMemberInGroupGoalDTO(goal.getGroupMember());
+      } else {
+        this.member = null;
+      }
+      this.progressRate = goal.getProgressRate();
       this.createdAt = goal.getCreatedAt();
       this.updatedAt = goal.getUpdatedAt();
+    }
+  }
+
+
+  @Data
+  public static class GroupMemberInGroupGoalDTO {
+
+    private Long id;
+    private String nickname;
+
+    public GroupMemberInGroupGoalDTO(GroupMember groupMember) {
+      this.id = groupMember.getMember().getId();
+      this.nickname = groupMember.getMember().getNickname();
     }
   }
 
@@ -54,16 +76,10 @@ public class GroupGoalAdminDTO {
 
     private Long id;
     private String title;
-    @JsonProperty("created_at")
-    private LocalDateTime createdAt;
-    @JsonProperty("updated_at")
-    private LocalDateTime updatedAt;
 
     public GroupInGoalDTO(Group group) {
       this.id = group.getId();
       this.title = group.getTitle();
-      this.createdAt = group.getCreatedAt();
-      this.updatedAt = group.getUpdatedAt();
     }
   }
 }

--- a/src/main/java/com/slide_todo/slide_todoApp/dto/goal/admin/GroupGoalDetailDTO.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/dto/goal/admin/GroupGoalDetailDTO.java
@@ -23,7 +23,7 @@ public class GroupGoalDetailDTO {
   private LocalDateTime updatedAt;
   @JsonProperty("group")
   private GroupInGoalDTO group;
-  @JsonProperty("group_todos")
+  @JsonProperty("todos")
   private List<GroupTodoInGoalDTO> groupTodos;
 
   public GroupGoalDetailDTO(GroupGoal goal) {
@@ -42,12 +42,12 @@ public class GroupGoalDetailDTO {
   public static class GroupInGoalDTO {
 
     private Long id;
-    @JsonProperty("group_name")
-    private String groupName;
+    @JsonProperty("title")
+    private String title;
 
     public GroupInGoalDTO(Group group) {
       this.id = group.getId();
-      this.groupName = group.getTitle();
+      this.title = group.getTitle();
     }
   }
 
@@ -89,7 +89,7 @@ public class GroupGoalDetailDTO {
     private String color;
 
     public GroupMemberInTodoDTO(GroupMember groupMember) {
-      this.id = groupMember.getId();
+      this.id = groupMember.getMember().getId();
       this.nickname = groupMember.getMember().getNickname();
       this.color = groupMember.getColor().getHexCode();
     }

--- a/src/main/java/com/slide_todo/slide_todoApp/dto/goal/admin/IndividualGoalDetailDTO.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/dto/goal/admin/IndividualGoalDetailDTO.java
@@ -22,7 +22,7 @@ public class IndividualGoalDetailDTO {
   private LocalDateTime updatedAt;
   @JsonProperty("member")
   private MemberInGoalDTO member;
-  @JsonProperty("individual_todos")
+  @JsonProperty("todos")
   private List<IndividualTodoInGoalDTO> individualTodos;
 
   public IndividualGoalDetailDTO(IndividualGoal goal) {

--- a/src/main/java/com/slide_todo/slide_todoApp/dto/member/admin/AdminMemberDetailDTO.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/dto/member/admin/AdminMemberDetailDTO.java
@@ -1,7 +1,6 @@
-package com.slide_todo.slide_todoApp.dto.member;
+package com.slide_todo.slide_todoApp.dto.member.admin;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.slide_todo.slide_todoApp.domain.goal.Goal;
 import com.slide_todo.slide_todoApp.domain.goal.IndividualGoal;
 import com.slide_todo.slide_todoApp.domain.group.GroupMember;
 import com.slide_todo.slide_todoApp.domain.member.Member;
@@ -11,7 +10,7 @@ import java.util.List;
 import lombok.Data;
 
 @Data
-public class MemberDetailDTO {
+public class AdminMemberDetailDTO {
 
   private Long id;
   private String email;
@@ -26,7 +25,7 @@ public class MemberDetailDTO {
   @JsonProperty("individual_goals")
   private List<GoalInMemberDetailDTO> goals;
 
-  public MemberDetailDTO(Member member) {
+  public AdminMemberDetailDTO(Member member) {
     this.id = member.getId();
     this.email = member.getEmail();
     this.nickname = member.getNickname();

--- a/src/main/java/com/slide_todo/slide_todoApp/dto/member/admin/AdminMemberListDTO.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/dto/member/admin/AdminMemberListDTO.java
@@ -1,0 +1,22 @@
+package com.slide_todo.slide_todoApp.dto.member.admin;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.slide_todo.slide_todoApp.domain.member.Member;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class AdminMemberListDTO {
+
+  @JsonProperty("total_count")
+  private Long totalCount;
+  @JsonProperty("current_page")
+  private Long currentPage;
+  private List<AdminMemberListRowDTO> members;
+
+  public AdminMemberListDTO(Long totalCount, Long currentPage, List<Member> members) {
+    this.totalCount = totalCount;
+    this.currentPage = currentPage;
+    this.members = members.stream().map(AdminMemberListRowDTO::new).toList();
+  }
+}

--- a/src/main/java/com/slide_todo/slide_todoApp/dto/member/admin/AdminMemberListRowDTO.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/dto/member/admin/AdminMemberListRowDTO.java
@@ -1,0 +1,29 @@
+package com.slide_todo.slide_todoApp.dto.member.admin;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.slide_todo.slide_todoApp.domain.member.Member;
+import java.time.LocalDate;
+import lombok.Data;
+
+@Data
+public class AdminMemberListRowDTO {
+
+  private Long id;
+  private String nickname;
+  private String email;
+  @JsonProperty("created_at")
+  private LocalDate createdAt;
+  @JsonProperty("updated_at")
+  private LocalDate updatedAt;
+  @JsonProperty("group_count")
+  private long groupCount;
+
+  public AdminMemberListRowDTO(Member member) {
+    this.id = member.getId();
+    this.nickname = member.getNickname();
+    this.email = member.getEmail();
+    this.createdAt = member.getCreatedAt().toLocalDate();
+    this.updatedAt = member.getUpdatedAt().toLocalDate();
+    this.groupCount = member.getGroupMembers().size();
+  }
+}

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/goal/BaseGoalRepository.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/goal/BaseGoalRepository.java
@@ -18,8 +18,8 @@ public interface BaseGoalRepository {
 
   /*어드민 페이지에서 그룹 목표 리스트 조회*/
   GroupGoalSearchResultDTO findGroupGoalByAdmin(
-      String groupName, String title, LocalDateTime createdAfter, LocalDateTime createdBefore,
-      long start, long limit
+      String nickname, String groupName, String title, LocalDateTime createdAfter,
+      LocalDateTime createdBefore, long start, long limit
   );
 
   /*삭제할 개인 목표 리스트 조회*/

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/goal/BaseGoalRepositoryImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/goal/BaseGoalRepositoryImpl.java
@@ -74,17 +74,25 @@ public class BaseGoalRepositoryImpl implements BaseGoalRepository {
   }
 
   @Override
-  public GroupGoalSearchResultDTO findGroupGoalByAdmin(String groupName, String title,
-      LocalDateTime createdAfter, LocalDateTime createdBefore, long start, long limit) {
+  public GroupGoalSearchResultDTO findGroupGoalByAdmin(String nickname, String groupName,
+      String title, LocalDateTime createdAfter, LocalDateTime createdBefore, long start, long limit) {
 
     StringBuilder queryBuilder = new StringBuilder("select gg from GroupGoal gg"
+        + " left join fetch gg.groupMember gm"
+        + " left join fetch gm.member"
         + " left join fetch gg.group g"
         + " where 1=1");
     StringBuilder countQueryBuilder = new StringBuilder(
         "select count(gg) from GroupGoal gg"
+            + " left join gg.groupMember gm"
+            + " left join gm.member"
             + " left join gg.group g"
             + " where 1=1");
 
+    if (nickname != null) {
+      queryBuilder.append(" and gm.member.nickname like :nickname");
+      countQueryBuilder.append(" and gm.member.nickname like :nickname");
+    }
     if (groupName != null) {
       queryBuilder.append(" and g.title like :groupName");
       countQueryBuilder.append(" and g.title like :groupName");
@@ -105,6 +113,10 @@ public class BaseGoalRepositoryImpl implements BaseGoalRepository {
     TypedQuery<GroupGoal> query = em.createQuery(queryBuilder.toString(), GroupGoal.class);
     TypedQuery<Long> countQuery = em.createQuery(countQueryBuilder.toString(), Long.class);
 
+    if (nickname != null) {
+      query.setParameter("nickname", "%" + nickname + "%");
+      countQuery.setParameter("nickname", "%" + nickname + "%");
+    }
     if (groupName != null) {
       query.setParameter("groupName", "%" + groupName + "%");
       countQuery.setParameter("groupName", "%" + groupName + "%");

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/goal/BaseGoalRepositoryImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/goal/BaseGoalRepositoryImpl.java
@@ -144,7 +144,6 @@ public class BaseGoalRepositoryImpl implements BaseGoalRepository {
           .setParameter("goalId", goal.getId())
           .getResultList());
     });
-
     return goals;
   }
 
@@ -164,7 +163,6 @@ public class BaseGoalRepositoryImpl implements BaseGoalRepository {
           .setParameter("goalId", goal.getId())
           .getResultList());
     });
-
     return goals;
   }
 
@@ -185,13 +183,12 @@ public class BaseGoalRepositoryImpl implements BaseGoalRepository {
   @Override
   public GroupGoal findGroupGoalDetail(Long goalId) {
     try {
-      GroupGoal goal = em.createQuery("select gg from GroupGoal gg"
+      return em.createQuery("select gg from GroupGoal gg"
           + " left join fetch gg.group"
           + " left join fetch gg.todos t"
           + " where gg.id = :goalId", GroupGoal.class)
           .setParameter("goalId", goalId)
           .getSingleResult();
-      return goal;
     } catch (NoResultException e) {
       throw new CustomException(Exceptions.GOAL_NOT_FOUND);
     }

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/member/BaseMemberRepositoryImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/member/BaseMemberRepositoryImpl.java
@@ -113,7 +113,8 @@ public class BaseMemberRepositoryImpl implements BaseMemberRepository {
   @Override
   public MemberSearchResultDTO findByNicknameAndEmailAndCreatedAt(String nickname,
       String email, LocalDateTime createdAfter, LocalDateTime createdBefore, long start, long limit) {
-    StringBuilder queryString = new StringBuilder("select m from Member m where 1=1");
+    StringBuilder queryString = new StringBuilder("select m from Member m"
+        + " left join fetch m.groupMembers gm where 1=1");
     StringBuilder countQueryString = new StringBuilder("select count(m) from Member m where 1=1");
 
     if (nickname != null) {

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/todo/BaseTodoRepository.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/todo/BaseTodoRepository.java
@@ -36,6 +36,12 @@ public interface BaseTodoRepository {
   /*삭제할 할 일 리스트 조회*/
   List<Todo> findTodosToDelete(List<Long> ids);
 
+  /*삭제할 개인 할 일 리스트 조회*/
+  List<IndividualTodo> findIndividualTodosToDelete(List<Long> ids);
+
+  /*삭제할 그룹 할 일 리스트 조회*/
+  List<GroupTodo> findGroupTodosToDelete(List<Long> ids);
+
   /*어드민 페이지 개인 할 일 리스트 조회*/
   IndividualTodoSearchResultDTO findIndividualTodoByAdmin(
       String nickname, String title, LocalDateTime createdAfter, LocalDateTime createdBefore,

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/todo/BaseTodoRepositoryImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/todo/BaseTodoRepositoryImpl.java
@@ -103,15 +103,37 @@ public class BaseTodoRepositoryImpl implements BaseTodoRepository {
   }
 
   @Override
+  public List<IndividualTodo> findIndividualTodosToDelete(List<Long> ids) {
+    return em.createQuery("select it from IndividualTodo it"
+            + " left join fetch it.goal g"
+            + " left join fetch it.note n"
+            + " where it.id in :ids", IndividualTodo.class)
+        .setParameter("ids", ids)
+        .getResultList();
+  }
+
+  @Override
+  public List<GroupTodo> findGroupTodosToDelete(List<Long> ids) {
+    return em.createQuery("select gt from GroupTodo gt"
+            + " left join fetch gt.goal g"
+            + " left join fetch gt.note n"
+            + " where gt.id in :ids", GroupTodo.class)
+        .setParameter("ids", ids)
+        .getResultList();
+  }
+
+  @Override
   public IndividualTodoSearchResultDTO findIndividualTodoByAdmin(String nickname, String title,
       LocalDateTime createdAfter, LocalDateTime createdBefore, long start, long limit) {
 
     StringBuilder queryBuilder = new StringBuilder("select it from IndividualTodo it"
         + " left join fetch it.goal g"
+        + " left join fetch g.member m"
         + " where 1=1");
     StringBuilder countQueryBuilder = new StringBuilder(
         "select count(it) from IndividualTodo it"
-            + " left join fetch it.goal g"
+            + " left join it.goal g"
+            + " left join g.member m"
             + " where 1=1");
 
     if (nickname != null) {
@@ -134,6 +156,7 @@ public class BaseTodoRepositoryImpl implements BaseTodoRepository {
     TypedQuery<IndividualTodo> query = em.createQuery(queryBuilder.toString(),
         IndividualTodo.class);
     TypedQuery<Long> countQuery = em.createQuery(countQueryBuilder.toString(), Long.class);
+
     if (nickname != null) {
       query.setParameter("nickname", "%" + nickname + "%");
       countQuery.setParameter("nickname", "%" + nickname + "%");
@@ -166,8 +189,8 @@ public class BaseTodoRepositoryImpl implements BaseTodoRepository {
         + " where 1=1");
     StringBuilder countQueryBuilder = new StringBuilder(
         "select count(gg) from GroupTodo gt"
-            + " left join fetch gt.goal g"
-            + " left join fetch g.group gg"
+            + " left join gt.goal g"
+            + " left join g.group gg"
             + " where 1=1");
 
     if (groupName != null) {

--- a/src/main/java/com/slide_todo/slide_todoApp/service/goal/AdminGoalService.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/service/goal/AdminGoalService.java
@@ -14,7 +14,7 @@ public interface AdminGoalService {
 
   /*어드민 페이지에서 그룹 목표 리스트 조회*/
   ResponseDTO<GroupGoalAdminDTO> getGroupGoalsByAdmin(long page, long limit, String groupName,
-      String title, String createdAfter, String createdBefore);
+      String nickname, String title, String createdAfter, String createdBefore);
 
   /*개인 목표 복수 삭제*/
   ResponseDTO<IndividualGoalAdminDTO> deleteIndividualGoalsByAdmin(long page, long limit,
@@ -22,7 +22,7 @@ public interface AdminGoalService {
 
   /*그룹 목표 복수 삭제*/
   ResponseDTO<GroupGoalAdminDTO> deleteGroupGoalsByAdmin(long page, long limit, String groupName,
-      String title, String createdAfter, String createdBefore, GoalIdsDTO goalIds);
+      String nickname, String title, String createdAfter, String createdBefore, GoalIdsDTO goalIds);
 
   /*목표 상세정보 조회*/
   ResponseDTO<?> getGoalDetail(Long goalId);

--- a/src/main/java/com/slide_todo/slide_todoApp/service/goal/AdminGoalServiceImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/service/goal/AdminGoalServiceImpl.java
@@ -60,9 +60,9 @@ public class AdminGoalServiceImpl implements AdminGoalService {
    */
   @Override
   public ResponseDTO<GroupGoalAdminDTO> getGroupGoalsByAdmin(long page, long limit,
-      String groupName, String title, String createdAfter, String createdBefore) {
+      String nickname, String groupName, String title, String createdAfter, String createdBefore) {
 
-    GroupGoalAdminDTO result = searchGroupGoals(page, limit, groupName, title,
+    GroupGoalAdminDTO result = searchGroupGoals(page, limit, nickname, groupName, title,
         createdAfter, createdBefore);
 
     return new ResponseDTO<>(result, Responses.OK);
@@ -112,7 +112,7 @@ public class AdminGoalServiceImpl implements AdminGoalService {
   @Override
   @Transactional
   public ResponseDTO<GroupGoalAdminDTO> deleteGroupGoalsByAdmin(long page, long limit,
-      String groupName, String title, String createdAfter, String createdBefore,
+      String nickname, String groupName, String title, String createdAfter, String createdBefore,
       GoalIdsDTO goalIds) {
 
     List<Long> ids = goalIds.getGoalIds();
@@ -122,7 +122,7 @@ public class AdminGoalServiceImpl implements AdminGoalService {
       g.deleteGoal();
     }
 
-    GroupGoalAdminDTO result = searchGroupGoals(page, limit, groupName, title,
+    GroupGoalAdminDTO result = searchGroupGoals(page, limit, nickname, groupName, title,
         createdAfter, createdBefore);
 
     return new ResponseDTO<>(result, Responses.OK);
@@ -208,7 +208,7 @@ public class AdminGoalServiceImpl implements AdminGoalService {
 
   /*그룹 목표 리스트 조회*/
   private GroupGoalAdminDTO searchGroupGoals(long page, long limit,
-      String groupName, String title, String createdAfter, String createdBefore) {
+      String nickname, String groupName, String title, String createdAfter, String createdBefore) {
     long start;
     if (limit != 0) {
       start = (page - 1) * limit;
@@ -233,7 +233,7 @@ public class AdminGoalServiceImpl implements AdminGoalService {
     }
 
     GroupGoalSearchResultDTO searchResult = goalRepository.findGroupGoalByAdmin(
-        groupName, title, parsedCreatedAfter, parsedCreatedBefore, start, limit
+        nickname, groupName, title, parsedCreatedAfter, parsedCreatedBefore, start, limit
     );
 
     return new GroupGoalAdminDTO(searchResult.getTotalCount(), page, searchResult.getGoals());

--- a/src/main/java/com/slide_todo/slide_todoApp/service/goal/GroupGoalService.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/service/goal/GroupGoalService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public interface GroupGoalService {
-    ResponseDTO<GroupGoalDTO> createGroupGoal(Long groupId,String title);
+    ResponseDTO<GroupGoalDTO> createGroupGoal(Long memberId, Long groupId,String title);
 
     ResponseDTO<?> getGroupGoals(Long groupId);
 

--- a/src/main/java/com/slide_todo/slide_todoApp/service/goal/GroupGoalServiceImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/service/goal/GroupGoalServiceImpl.java
@@ -3,6 +3,7 @@ package com.slide_todo.slide_todoApp.service.goal;
 import com.slide_todo.slide_todoApp.domain.goal.GroupGoal;
 import com.slide_todo.slide_todoApp.domain.group.Group;
 import com.slide_todo.slide_todoApp.domain.group.GroupMember;
+import com.slide_todo.slide_todoApp.domain.member.Member;
 import com.slide_todo.slide_todoApp.domain.todo.GroupTodo;
 import com.slide_todo.slide_todoApp.dto.goal.GoalTodosResponseDTO;
 import com.slide_todo.slide_todoApp.dto.goal.GroupGoalDTO;
@@ -11,6 +12,7 @@ import com.slide_todo.slide_todoApp.dto.goal.GroupProgressDTO;
 import com.slide_todo.slide_todoApp.repository.goal.GroupGoalRepository;
 import com.slide_todo.slide_todoApp.repository.group.GroupMemberRepository;
 import com.slide_todo.slide_todoApp.repository.group.GroupRepository;
+import com.slide_todo.slide_todoApp.repository.member.MemberRepository;
 import com.slide_todo.slide_todoApp.repository.todo.TodoRepository;
 import com.slide_todo.slide_todoApp.util.response.ResponseDTO;
 import com.slide_todo.slide_todoApp.util.response.Responses;
@@ -35,7 +37,8 @@ public class GroupGoalServiceImpl implements GroupGoalService {
     //그룹 목표 생성
     @Override
     @Transactional
-    public ResponseDTO<GroupGoalDTO> createGroupGoal(Long groupId,String title){
+    public ResponseDTO<GroupGoalDTO> createGroupGoal(Long memberId, Long groupId,String title){
+        GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId);
         individualGoalServiceImpl.checkTitleLength(title);
 
         Group group = groupRepository.findById(groupId).get();
@@ -43,6 +46,7 @@ public class GroupGoalServiceImpl implements GroupGoalService {
         GroupGoal groupGoal = GroupGoal.builder()
                 .title(title)
                 .group(group)
+                .groupMember(groupMember)
                 .build();
 
         groupGoalRepository.save(groupGoal);

--- a/src/main/java/com/slide_todo/slide_todoApp/service/member/AdminMemberService.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/service/member/AdminMemberService.java
@@ -1,25 +1,25 @@
 package com.slide_todo.slide_todoApp.service.member;
 
-import com.slide_todo.slide_todoApp.dto.member.MemberDetailDTO;
+import com.slide_todo.slide_todoApp.dto.member.admin.AdminMemberDetailDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberIdsDTO;
-import com.slide_todo.slide_todoApp.dto.member.MemberListDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberUpdateDTO;
+import com.slide_todo.slide_todoApp.dto.member.admin.AdminMemberListDTO;
 import com.slide_todo.slide_todoApp.util.response.ResponseDTO;
 import jakarta.annotation.Nullable;
 
 public interface AdminMemberService {
 
   /*어드민 페이지에서 유저 리스트 조회*/
-  ResponseDTO<MemberListDTO> getAllMembers(long page, long limit, @Nullable String nickname,
+  ResponseDTO<AdminMemberListDTO> getAllMembers(long page, long limit, @Nullable String nickname,
       @Nullable String email, @Nullable String createdAfter, @Nullable String createdBefore);
 
   /*어드민 페이지에서 유저 상세정보 조회*/
-  ResponseDTO<MemberDetailDTO> getMemberDetail(Long memberId);
+  ResponseDTO<AdminMemberDetailDTO> getMemberDetail(Long memberId);
 
   /*복수 유저 삭제*/
-  ResponseDTO<MemberListDTO> deleteMembers(MemberIdsDTO request, long page, long limit,
+  ResponseDTO<AdminMemberListDTO> deleteMembers(MemberIdsDTO request, long page, long limit,
       String nickname, String email, String createdAfter, String createdBefore);
 
   /*유저 데이터 수정*/
-  ResponseDTO<MemberDetailDTO> updateMember(Long memberId, MemberUpdateDTO request);
+  ResponseDTO<AdminMemberDetailDTO> updateMember(Long memberId, MemberUpdateDTO request);
 }

--- a/src/main/java/com/slide_todo/slide_todoApp/service/member/AdminMemberServiceImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/service/member/AdminMemberServiceImpl.java
@@ -1,11 +1,11 @@
 package com.slide_todo.slide_todoApp.service.member;
 
 import com.slide_todo.slide_todoApp.domain.member.Member;
-import com.slide_todo.slide_todoApp.dto.member.MemberDetailDTO;
+import com.slide_todo.slide_todoApp.dto.member.admin.AdminMemberDetailDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberIdsDTO;
-import com.slide_todo.slide_todoApp.dto.member.MemberListDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberSearchResultDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberUpdateDTO;
+import com.slide_todo.slide_todoApp.dto.member.admin.AdminMemberListDTO;
 import com.slide_todo.slide_todoApp.repository.member.MemberRepository;
 import com.slide_todo.slide_todoApp.util.exception.CustomException;
 import com.slide_todo.slide_todoApp.util.exception.Exceptions;
@@ -29,25 +29,25 @@ public class AdminMemberServiceImpl implements AdminMemberService {
   private final Pattern emailPattern = Pattern.compile(EMAIL_PATTERN);
 
   @Override
-  public ResponseDTO<MemberListDTO> getAllMembers(long page, long limit,
+  public ResponseDTO<AdminMemberListDTO> getAllMembers(long page, long limit,
       String nickname, String email, String createdAfter, String createdBefore) {
 
-    MemberListDTO searchResult = searchMembers(page, limit, nickname, email, createdAfter,
+    AdminMemberListDTO searchResult = searchMembers(page, limit, nickname, email, createdAfter,
         createdBefore);
 
     return new ResponseDTO<>(searchResult, Responses.OK);
   }
 
   @Override
-  public ResponseDTO<MemberDetailDTO> getMemberDetail(Long memberId) {
+  public ResponseDTO<AdminMemberDetailDTO> getMemberDetail(Long memberId) {
     Member member = memberRepository.findMemberWithGoalAndGroupMember(memberId);
-    return new ResponseDTO<>(new MemberDetailDTO(member), Responses.OK);
+    return new ResponseDTO<>(new AdminMemberDetailDTO(member), Responses.OK);
 
   }
 
   @Override
   @Transactional
-  public ResponseDTO<MemberListDTO> deleteMembers(MemberIdsDTO request, long page, long limit,
+  public ResponseDTO<AdminMemberListDTO> deleteMembers(MemberIdsDTO request, long page, long limit,
       String nickname, String email, String createdAfter, String createdBefore) {
     List<Long> ids = request.getMemberIds();
 
@@ -56,7 +56,7 @@ public class AdminMemberServiceImpl implements AdminMemberService {
       m.deleteMember();
     }
 
-    MemberListDTO searchResult = searchMembers(page, limit, nickname, email, createdAfter,
+    AdminMemberListDTO searchResult = searchMembers(page, limit, nickname, email, createdAfter,
         createdBefore);
 
     return new ResponseDTO<>(searchResult, Responses.OK);
@@ -64,7 +64,7 @@ public class AdminMemberServiceImpl implements AdminMemberService {
 
   @Override
   @Transactional
-  public ResponseDTO<MemberDetailDTO> updateMember(Long memberId, MemberUpdateDTO request) {
+  public ResponseDTO<AdminMemberDetailDTO> updateMember(Long memberId, MemberUpdateDTO request) {
     Member member = memberRepository.findByMemberId(memberId);
 
     if (request.getEmail() != null) {
@@ -77,10 +77,10 @@ public class AdminMemberServiceImpl implements AdminMemberService {
     }
 
     member.updateMember(request.getEmail(), request.getNickname());
-    return new ResponseDTO<>(new MemberDetailDTO(member), Responses.OK);
+    return new ResponseDTO<>(new AdminMemberDetailDTO(member), Responses.OK);
   }
 
-  private MemberListDTO searchMembers(long page, long limit,
+  private AdminMemberListDTO searchMembers(long page, long limit,
       String nickname, String email, String createdAfter, String createdBefore) {
     long start;
     if (limit != 0) {
@@ -109,7 +109,9 @@ public class AdminMemberServiceImpl implements AdminMemberService {
         nickname, email,
         parsedCreatedAfter, parsedCreatedBefore, start, limit);
 
-    return new MemberListDTO(searchResult.getTotalCount(), page, searchResult.getMembers());
+    return new AdminMemberListDTO(searchResult.getTotalCount(), page, searchResult.getMembers());
+
+//    return new MemberListDTO(searchResult.getTotalCount(), page, searchResult.getMembers());
   }
 
   /*이메일 유효성 및 중복 검사*/


### PR DESCRIPTION
### 이슈 번호
- [ ] #19 
- [ ] #36
### 작업한 내용
- GroupGoal 엔티티에 작성자를 저장하기 위한 groupMember 필드 추가
- 어드민의 노트 관리 기능 테스트 코드 추가