### PR TITLE
[FEAT] 회원 정보 조회 API 추가 외 2

### DIFF
--- a/src/main/java/com/slide_todo/slide_todoApp/controller/MemberController.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.slide_todo.slide_todoApp.controller;
 
 import com.slide_todo.slide_todoApp.dto.jwt.RefreshTokenDTO;
 import com.slide_todo.slide_todoApp.dto.jwt.TokenPairDTO;
+import com.slide_todo.slide_todoApp.dto.member.MemberDashboardDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberInfoDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberUpdateDTO;
 import com.slide_todo.slide_todoApp.dto.member.DuplicationCheckDTO;
@@ -111,5 +112,14 @@ public class MemberController {
   public ResponseDTO<MemberInfoDTO> getMemberInfo(HttpServletRequest request) {
     Long memberId = jwtProvider.getMemberId(request);
     return memberService.getMemberInfo(memberId);
+  }
+
+
+  @GetMapping("/dashboard")
+  @Operation(summary = "회원 대시보드 조회", description = "회원 대시보드 조회 API입니다.")
+  @ApiResponse(responseCode = "200", description = "회원 대시보드 조회 성공")
+  public ResponseDTO<MemberDashboardDTO> getMemberDashboard(HttpServletRequest request) {
+    Long memberId = jwtProvider.getMemberId(request);
+    return memberService.getMemberDashboard(memberId);
   }
 }

--- a/src/main/java/com/slide_todo/slide_todoApp/controller/MemberController.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.slide_todo.slide_todoApp.controller;
 
 import com.slide_todo.slide_todoApp.dto.jwt.RefreshTokenDTO;
 import com.slide_todo.slide_todoApp.dto.jwt.TokenPairDTO;
+import com.slide_todo.slide_todoApp.dto.member.MemberInfoDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberUpdateDTO;
 import com.slide_todo.slide_todoApp.dto.member.DuplicationCheckDTO;
 import com.slide_todo.slide_todoApp.dto.member.SigninDTO;
@@ -101,5 +102,14 @@ public class MemberController {
   public ResponseDTO<?> deleteMember(HttpServletRequest request) {
     Long memberId = jwtProvider.getMemberId(request);
     return memberService.deleteMember(memberId);
+  }
+
+
+  @GetMapping("/info")
+  @Operation(summary = "회원 정보 조회", description = "회원 정보 조회 API입니다.")
+  @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공")
+  public ResponseDTO<MemberInfoDTO> getMemberInfo(HttpServletRequest request) {
+    Long memberId = jwtProvider.getMemberId(request);
+    return memberService.getMemberInfo(memberId);
   }
 }

--- a/src/main/java/com/slide_todo/slide_todoApp/domain/goal/GroupGoal.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/domain/goal/GroupGoal.java
@@ -2,10 +2,11 @@ package com.slide_todo.slide_todoApp.domain.goal;
 
 import com.slide_todo.slide_todoApp.domain.group.Group;
 import com.slide_todo.slide_todoApp.domain.group.GroupMember;
-import com.slide_todo.slide_todoApp.domain.todo.GroupTodo;
-import jakarta.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,7 +19,7 @@ public class GroupGoal extends Goal {
     @JoinColumn(name = "group_id")
     private Group group;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_member_id")
     private GroupMember groupMember;
 

--- a/src/main/java/com/slide_todo/slide_todoApp/dto/member/MemberDashboardDTO.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/dto/member/MemberDashboardDTO.java
@@ -1,0 +1,75 @@
+package com.slide_todo.slide_todoApp.dto.member;
+
+import static java.util.Comparator.comparing;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.slide_todo.slide_todoApp.domain.goal.Goal;
+import com.slide_todo.slide_todoApp.domain.group.Group;
+import com.slide_todo.slide_todoApp.domain.member.Member;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class MemberDashboardDTO {
+
+  private Long id;
+  private String nickname;
+  private String email;
+  @JsonProperty("individual_goals")
+  private List<GoalInDashboardDTO> individualGoals;
+  private List<GroupInDashboardDTO> groups;
+
+  public MemberDashboardDTO(Member member, List<Group> groups
+  ) {
+    this.id = member.getId();
+    this.nickname = member.getNickname();
+    this.email = member.getEmail();
+    this.individualGoals = member.getIndividualGoals().stream()
+        .map(GoalInDashboardDTO::new)
+        .sorted(comparing(GoalInDashboardDTO::getCreatedAt).reversed())
+        .toList();
+    this.groups = groups.stream()
+        .map(GroupInDashboardDTO::new)
+        .sorted(comparing(GroupInDashboardDTO::getCreatedAt).reversed())
+        .toList();
+  }
+
+
+  @Data
+  public static class GoalInDashboardDTO {
+
+    private Long id;
+    private String title;
+    @JsonIgnore
+    private LocalDateTime createdAt;
+
+    public GoalInDashboardDTO(Goal goal) {
+      this.id = goal.getId();
+      this.title = goal.getTitle();
+      this.createdAt = goal.getCreatedAt();
+    }
+  }
+
+  @Data
+  public static class GroupInDashboardDTO {
+
+    private Long id;
+    private String title;
+    @JsonIgnore
+    private LocalDateTime createdAt;
+    @JsonProperty("group_goals")
+    private List<GoalInDashboardDTO> groupGoals;
+
+    public GroupInDashboardDTO(Group group) {
+      this.id = group.getId();
+      this.title = group.getTitle();
+      this.createdAt = group.getCreatedAt();
+      this.groupGoals = group.getGroupGoals().stream()
+          .map(GoalInDashboardDTO::new)
+          .sorted(comparing(GoalInDashboardDTO::getCreatedAt).reversed())
+          .toList();
+    }
+  }
+}

--- a/src/main/java/com/slide_todo/slide_todoApp/dto/member/MemberInfoDTO.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/dto/member/MemberInfoDTO.java
@@ -1,0 +1,21 @@
+package com.slide_todo.slide_todoApp.dto.member;
+
+import com.slide_todo.slide_todoApp.domain.member.Member;
+import lombok.Data;
+
+/**
+ * 간단한 유저 정보를 조회하는 DTO
+ */
+@Data
+public class MemberInfoDTO {
+
+  private Long id;
+  private String nickname;
+  private String email;
+
+  public MemberInfoDTO(Member member) {
+    this.id = member.getId();
+    this.nickname = member.getNickname();
+    this.email = member.getEmail();
+  }
+}

--- a/src/main/java/com/slide_todo/slide_todoApp/dto/todo/GroupTodoDTO.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/dto/todo/GroupTodoDTO.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.slide_todo.slide_todoApp.domain.goal.Goal;
 import com.slide_todo.slide_todoApp.domain.todo.GroupTodo;
 import com.slide_todo.slide_todoApp.dto.group.GroupMemberDTO;
+import java.math.BigDecimal;
 import lombok.Data;
 
 @Data
@@ -17,6 +18,8 @@ public class GroupTodoDTO {
   private String createdAt;
   @JsonProperty("updated_at")
   private String updatedAt;
+  @JsonProperty("progress_rate")
+  private BigDecimal progressRate;
   @JsonProperty("note_id")
   private Long noteId;
   private GoalInTodoDTO goal;
@@ -34,6 +37,7 @@ public class GroupTodoDTO {
     }
     this.createdAt = todo.getCreatedAt().toString();
     this.updatedAt = todo.getUpdatedAt().toString();
+    this.progressRate = goal.getProgressRate();
     if (todo.getNote() != null) {
       this.noteId = todo.getNote().getId();
     } else {

--- a/src/main/java/com/slide_todo/slide_todoApp/dto/todo/IndividualTodoDTO.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/dto/todo/IndividualTodoDTO.java
@@ -3,6 +3,7 @@ package com.slide_todo.slide_todoApp.dto.todo;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.slide_todo.slide_todoApp.domain.goal.Goal;
 import com.slide_todo.slide_todoApp.domain.todo.IndividualTodo;
+import java.math.BigDecimal;
 import lombok.Data;
 
 @Data
@@ -16,6 +17,8 @@ public class IndividualTodoDTO {
   private String createdAt;
   @JsonProperty("updated_at")
   private String updatedAt;
+  @JsonProperty("progress_rate")
+  private BigDecimal progressRate;
   @JsonProperty("note_id")
   private Long noteId;
   private GoalInTodoDTO goal;
@@ -26,6 +29,7 @@ public class IndividualTodoDTO {
     this.isDone = todo.getIsDone();
     this.createdAt = todo.getCreatedAt().toString();
     this.updatedAt = todo.getUpdatedAt().toString();
+    this.progressRate = goal.getProgressRate();
     if (todo.getNote() != null) {
       this.noteId = todo.getNote().getId();
     } else {

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/group/GroupRepository.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/group/GroupRepository.java
@@ -36,4 +36,6 @@ public interface GroupRepository extends JpaRepository<Group, Long>, JpaSpecific
 
     List<Group> findAll(Specification<Group> spec);
 
+    @Query("select g from Group g left join fetch g.groupGoals where g.id in :groupIds")
+    List<Group> findAllByGroupIds(List<Long> groupIds);
 }

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/member/BaseMemberRepository.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/member/BaseMemberRepository.java
@@ -1,7 +1,6 @@
 package com.slide_todo.slide_todoApp.repository.member;
 
 import com.slide_todo.slide_todoApp.domain.member.Member;
-import com.slide_todo.slide_todoApp.domain.member.MemberRole;
 import com.slide_todo.slide_todoApp.dto.member.MemberSearchResultDTO;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,14 +16,6 @@ public interface BaseMemberRepository {
   Member findByNickname(String nickname);
 
   Boolean existsByNickname(String nickname);
-
-  Long countByRole(MemberRole role);
-
-  List<Member> findByRoll(MemberRole role, int page, int limit);
-
-  Long countAll();
-
-  List<Member> findAll(int page, int limit);
 
   MemberSearchResultDTO findByNicknameAndEmailAndCreatedAt(
       String nickname, String email, LocalDateTime createdAfter,

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/member/BaseMemberRepositoryImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/member/BaseMemberRepositoryImpl.java
@@ -75,7 +75,8 @@ public class BaseMemberRepositoryImpl implements BaseMemberRepository {
 
   @Override
   public MemberSearchResultDTO findByNicknameAndEmailAndCreatedAt(String nickname,
-      String email, LocalDateTime createdAfter, LocalDateTime createdBefore, long start, long limit) {
+      String email, LocalDateTime createdAfter, LocalDateTime createdBefore, long start,
+      long limit) {
     StringBuilder queryString = new StringBuilder("select m from Member m"
         + " left join fetch m.groupMembers gm where 1=1");
     StringBuilder countQueryString = new StringBuilder("select count(m) from Member m where 1=1");
@@ -134,7 +135,8 @@ public class BaseMemberRepositoryImpl implements BaseMemberRepository {
           .getSingleResult();
 
       member.updateGroupMembers(em.createQuery("select gm from GroupMember  gm"
-          + " where gm.member in :member", GroupMember.class)
+              + " left join fetch gm.group"
+              + " where gm.member in :member", GroupMember.class)
           .setParameter("member", member)
           .getResultList());
 
@@ -159,7 +161,7 @@ public class BaseMemberRepositoryImpl implements BaseMemberRepository {
               + " where gm.member in :member", GroupMember.class)
           .setParameter("member", member)
           .getResultList());
-    } );
+    });
 
     return members;
   }

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/member/BaseMemberRepositoryImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/member/BaseMemberRepositoryImpl.java
@@ -2,8 +2,6 @@ package com.slide_todo.slide_todoApp.repository.member;
 
 import com.slide_todo.slide_todoApp.domain.group.GroupMember;
 import com.slide_todo.slide_todoApp.domain.member.Member;
-import com.slide_todo.slide_todoApp.domain.member.MemberRole;
-import com.slide_todo.slide_todoApp.domain.todo.IndividualTodo;
 import com.slide_todo.slide_todoApp.dto.member.MemberSearchResultDTO;
 import com.slide_todo.slide_todoApp.util.exception.CustomException;
 import com.slide_todo.slide_todoApp.util.exception.Exceptions;
@@ -11,7 +9,6 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.stereotype.Repository;
@@ -74,42 +71,6 @@ public class BaseMemberRepositoryImpl implements BaseMemberRepository {
         .setParameter("nickname", nickname)
         .setMaxResults(1)
         .getResultList().isEmpty();
-  }
-
-  @Override
-  public Long countByRole(MemberRole role) {
-    return em.createQuery("select count(m) from Member m"
-            + " where m.role =:role", Long.class)
-        .setParameter("role", role)
-        .getSingleResult();
-  }
-
-  @Override
-  public List<Member> findByRoll(MemberRole role, int page, int limit) {
-    int first = (page - 1) * limit;
-    return em.createQuery("select m from Member m"
-            + " where m.role =:role"
-            + " order by m.createdAt desc", Member.class)
-        .setParameter("role", role)
-        .setFirstResult(first)
-        .setMaxResults(first + limit)
-        .getResultList();
-  }
-
-  @Override
-  public Long countAll() {
-    return em.createQuery("select count(m) from Member m", Long.class)
-        .getSingleResult();
-  }
-
-  @Override
-  public List<Member> findAll(int page, int limit) {
-    int first = (page - 1) * limit;
-    return em.createQuery("select m from Member m"
-            + " order by m.createdAt desc", Member.class)
-        .setFirstResult(first)
-        .setMaxResults(first + limit)
-        .getResultList();
   }
 
   @Override

--- a/src/main/java/com/slide_todo/slide_todoApp/service/member/MemberService.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/service/member/MemberService.java
@@ -2,6 +2,7 @@ package com.slide_todo.slide_todoApp.service.member;
 
 import com.slide_todo.slide_todoApp.dto.jwt.RefreshTokenDTO;
 import com.slide_todo.slide_todoApp.dto.jwt.TokenPairDTO;
+import com.slide_todo.slide_todoApp.dto.member.MemberInfoDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberUpdateDTO;
 import com.slide_todo.slide_todoApp.dto.member.DuplicationCheckDTO;
 import com.slide_todo.slide_todoApp.dto.member.SigninDTO;
@@ -9,6 +10,8 @@ import com.slide_todo.slide_todoApp.dto.member.SignupDTO;
 import com.slide_todo.slide_todoApp.util.response.ResponseDTO;
 
 public interface MemberService {
+
+  ResponseDTO<MemberInfoDTO> getMemberInfo(Long memberId);
 
   ResponseDTO<TokenPairDTO> signup(SignupDTO request);
 

--- a/src/main/java/com/slide_todo/slide_todoApp/service/member/MemberService.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/service/member/MemberService.java
@@ -2,6 +2,7 @@ package com.slide_todo.slide_todoApp.service.member;
 
 import com.slide_todo.slide_todoApp.dto.jwt.RefreshTokenDTO;
 import com.slide_todo.slide_todoApp.dto.jwt.TokenPairDTO;
+import com.slide_todo.slide_todoApp.dto.member.MemberDashboardDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberInfoDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberUpdateDTO;
 import com.slide_todo.slide_todoApp.dto.member.DuplicationCheckDTO;
@@ -12,6 +13,8 @@ import com.slide_todo.slide_todoApp.util.response.ResponseDTO;
 public interface MemberService {
 
   ResponseDTO<MemberInfoDTO> getMemberInfo(Long memberId);
+
+  ResponseDTO<MemberDashboardDTO> getMemberDashboard(Long memberId);
 
   ResponseDTO<TokenPairDTO> signup(SignupDTO request);
 

--- a/src/main/java/com/slide_todo/slide_todoApp/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/service/member/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package com.slide_todo.slide_todoApp.service.member;
 import com.slide_todo.slide_todoApp.domain.member.Member;
 import com.slide_todo.slide_todoApp.dto.jwt.RefreshTokenDTO;
 import com.slide_todo.slide_todoApp.dto.jwt.TokenPairDTO;
+import com.slide_todo.slide_todoApp.dto.member.MemberInfoDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberUpdateDTO;
 import com.slide_todo.slide_todoApp.dto.member.DuplicationCheckDTO;
 import com.slide_todo.slide_todoApp.dto.member.SigninDTO;
@@ -36,6 +37,12 @@ public class MemberServiceImpl implements MemberService {
       "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[@#$%^&+=!.])(?=\\S+$).{8,}$";
   private final Pattern passwordPattern = Pattern.compile(PASSWORD_PATTERN);
 
+
+  @Override
+  public ResponseDTO<MemberInfoDTO> getMemberInfo(Long memberId) {
+    Member member = memberRepository.findByMemberId(memberId);
+    return new ResponseDTO<>(new MemberInfoDTO(member), Responses.OK);
+  }
 
   @Override
   @Transactional

--- a/src/main/java/com/slide_todo/slide_todoApp/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/service/member/MemberServiceImpl.java
@@ -1,13 +1,16 @@
 package com.slide_todo.slide_todoApp.service.member;
 
+import com.slide_todo.slide_todoApp.domain.group.Group;
 import com.slide_todo.slide_todoApp.domain.member.Member;
 import com.slide_todo.slide_todoApp.dto.jwt.RefreshTokenDTO;
 import com.slide_todo.slide_todoApp.dto.jwt.TokenPairDTO;
+import com.slide_todo.slide_todoApp.dto.member.DuplicationCheckDTO;
+import com.slide_todo.slide_todoApp.dto.member.MemberDashboardDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberInfoDTO;
 import com.slide_todo.slide_todoApp.dto.member.MemberUpdateDTO;
-import com.slide_todo.slide_todoApp.dto.member.DuplicationCheckDTO;
 import com.slide_todo.slide_todoApp.dto.member.SigninDTO;
 import com.slide_todo.slide_todoApp.dto.member.SignupDTO;
+import com.slide_todo.slide_todoApp.repository.group.GroupRepository;
 import com.slide_todo.slide_todoApp.repository.member.MemberRepository;
 import com.slide_todo.slide_todoApp.util.exception.CustomException;
 import com.slide_todo.slide_todoApp.util.exception.Exceptions;
@@ -15,6 +18,7 @@ import com.slide_todo.slide_todoApp.util.jwt.JwtProvider;
 import com.slide_todo.slide_todoApp.util.jwt.TokenType;
 import com.slide_todo.slide_todoApp.util.response.ResponseDTO;
 import com.slide_todo.slide_todoApp.util.response.Responses;
+import java.util.List;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
 
   private final MemberRepository memberRepository;
+  private final GroupRepository groupRepository;
   private final PasswordEncoder passwordEncoder;
   private final JwtProvider jwtProvider;
 
@@ -42,6 +47,19 @@ public class MemberServiceImpl implements MemberService {
   public ResponseDTO<MemberInfoDTO> getMemberInfo(Long memberId) {
     Member member = memberRepository.findByMemberId(memberId);
     return new ResponseDTO<>(new MemberInfoDTO(member), Responses.OK);
+  }
+
+  @Override
+  public ResponseDTO<MemberDashboardDTO> getMemberDashboard(Long memberId) {
+    Member member = memberRepository.findMemberWithGoalAndGroupMember(memberId);
+
+    List<Long> groupIds = member.getGroupMembers().stream()
+        .map(groupMember -> groupMember.getGroup().getId())
+        .toList();
+
+    List<Group> groups = groupRepository.findAllByGroupIds(groupIds);
+
+    return new ResponseDTO<>(new MemberDashboardDTO(member, groups), Responses.OK);
   }
 
   @Override


### PR DESCRIPTION
### 이슈 번호
- [ ] #1 
### 작업한 내용
- 회원 정보 조회 API 추가
- 대시보드 렌더링에 필요한 정보 조회 API 추가
  - 회원 정보
  - 회원의 개인 목표
  - 회원이 속한 그룹 + 그룹 목표
- 할 일 API 응답 DTO에 해당 할 일이 속한 목표의 진행률 필드 추가