### PR TITLE
[FIX] GroupMember 엔티티의 todoCount가 계속 증가하던 오류 수정

### DIFF
--- a/src/main/java/com/slide_todo/slide_todoApp/service/todo/TodoServiceImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/service/todo/TodoServiceImpl.java
@@ -339,8 +339,13 @@ public class TodoServiceImpl implements TodoService {
       throw new CustomException(Exceptions.NOT_CHARGED_GROUP_MEMBER);
     }
 
-    groupMember.increaseTodoCount();
+//    groupMember.increaseTodoCount();
     todo.updateGroupTodoDone();
+    if (todo.getIsDone()) {
+      groupMember.increaseTodoCount();
+    } else {
+      groupMember.decreaseTodoCount();
+    }
     goal.updateProgressRate();
     return todo;
   }


### PR DESCRIPTION
### 이슈 번호
- [ ] #7 
### 작업한 내용
- 그룹 할 일의 완료를 취소하더라도 GroupMember 엔티티의 todoCount가 증가하던 오류 수정