### PR TITLE
[FIX] 목표에 따른 노트 조회 시 담당자 속성이 항상 null이던 예외 수정

### DIFF
--- a/src/main/java/com/slide_todo/slide_todoApp/repository/group/BaseGroupMemberRepository.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/group/BaseGroupMemberRepository.java
@@ -1,8 +1,13 @@
 package com.slide_todo.slide_todoApp.repository.group;
 
 import com.slide_todo.slide_todoApp.domain.group.GroupMember;
+import java.util.List;
+import java.util.Map;
 
 public interface BaseGroupMemberRepository {
 
   GroupMember findByMemberIdAndGroupId(Long memberId, Long groupId);
+
+  /*그룹 할 일의 ID 목록으로 담당자 조회*/
+  Map<Long, GroupMember> findAllByGroupTodoIds(List<Long> groupTodoIds);
 }

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/group/BaseGroupMemberRepositoryImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/group/BaseGroupMemberRepositoryImpl.java
@@ -1,12 +1,15 @@
 package com.slide_todo.slide_todoApp.repository.group;
 
 import com.slide_todo.slide_todoApp.domain.group.GroupMember;
+import com.slide_todo.slide_todoApp.domain.todo.GroupTodo;
 import com.slide_todo.slide_todoApp.util.exception.CustomException;
 import com.slide_todo.slide_todoApp.util.exception.Exceptions;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.PersistenceContext;
-import org.springframework.data.jpa.repository.Query;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -28,5 +31,18 @@ public class BaseGroupMemberRepositoryImpl implements BaseGroupMemberRepository 
       throw new CustomException(Exceptions.NO_PERMISSION_FOR_THE_GROUP);
     }
 
+  }
+
+  @Override
+  public Map<Long, GroupMember> findAllByGroupTodoIds(List<Long> groupTodoIds) {
+    List<GroupTodo> todos = em.createQuery("select gt from GroupTodo gt"
+            + " left join fetch gt.memberInCharge gm"
+            + " left join fetch gm.member m"
+            + " where gt.id in :groupTodoIds"
+            + " and gt.memberInCharge is not null", GroupTodo.class)
+        .setParameter("groupTodoIds", groupTodoIds)
+        .getResultList();
+
+    return todos.stream().collect(Collectors.toMap(GroupTodo::getId, GroupTodo::getMemberInCharge));
   }
 }


### PR DESCRIPTION
### 이슈 번호
- [ ] #8 
### 작업한 내용
- 목표에 따른 노트 조회 시 담당자 속성이 항상 null이던 예외 수정