### PR TITLE
[FEAT] 어드민 페이지 그룹 목표 목록 조회 API에서 그룹 별 조회 파라미터 추가

### DIFF
--- a/src/main/java/com/slide_todo/slide_todoApp/controller/AdminGoalController.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/controller/AdminGoalController.java
@@ -67,6 +67,7 @@ public class AdminGoalController {
       HttpServletRequest request,
       @Parameter(description = "검색할 페이지 번호") @RequestParam long page,
       @Parameter(description = "한 페이지에 검색할 데이터 수") @RequestParam long limit,
+      @Parameter(description = "검색할 그룹 ID 조건") @RequestParam(required = false) Long groupId,
       @Parameter(description = "검색할 닉네임 조건") @RequestParam(required = false) String nickname,
       @Parameter(description = "검색할 그룹 이름 조건")
       @RequestParam(required = false) String groupName,
@@ -77,7 +78,7 @@ public class AdminGoalController {
       @RequestParam(required = false) String createdBefore
   ) {
     Long adminId = jwtProvider.getAdminMemberId(request);
-    return adminGoalService.getGroupGoalsByAdmin(page, limit, nickname, groupName, title,
+    return adminGoalService.getGroupGoalsByAdmin(groupId, page, limit, nickname, groupName, title,
         createdAfter, createdBefore);
   }
 

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/goal/BaseGoalRepository.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/goal/BaseGoalRepository.java
@@ -18,7 +18,7 @@ public interface BaseGoalRepository {
 
   /*어드민 페이지에서 그룹 목표 리스트 조회*/
   GroupGoalSearchResultDTO findGroupGoalByAdmin(
-      String nickname, String groupName, String title, LocalDateTime createdAfter,
+      Long groupId, String nickname, String groupName, String title, LocalDateTime createdAfter,
       LocalDateTime createdBefore, long start, long limit
   );
 

--- a/src/main/java/com/slide_todo/slide_todoApp/repository/goal/BaseGoalRepositoryImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/repository/goal/BaseGoalRepositoryImpl.java
@@ -73,7 +73,7 @@ public class BaseGoalRepositoryImpl implements BaseGoalRepository {
   }
 
   @Override
-  public GroupGoalSearchResultDTO findGroupGoalByAdmin(String nickname, String groupName,
+  public GroupGoalSearchResultDTO findGroupGoalByAdmin(Long groupId, String nickname, String groupName,
       String title, LocalDateTime createdAfter, LocalDateTime createdBefore, long start, long limit) {
 
     StringBuilder queryBuilder = new StringBuilder("select gg from GroupGoal gg"
@@ -88,6 +88,10 @@ public class BaseGoalRepositoryImpl implements BaseGoalRepository {
             + " left join gg.group g"
             + " where 1=1");
 
+    if (groupId != null) {
+      queryBuilder.append(" and g.id = :groupId");
+      countQueryBuilder.append(" and g.id = :groupId");
+    }
     if (nickname != null) {
       queryBuilder.append(" and gm.member.nickname like :nickname");
       countQueryBuilder.append(" and gm.member.nickname like :nickname");
@@ -113,6 +117,10 @@ public class BaseGoalRepositoryImpl implements BaseGoalRepository {
     TypedQuery<GroupGoal> query = em.createQuery(queryBuilder.toString(), GroupGoal.class);
     TypedQuery<Long> countQuery = em.createQuery(countQueryBuilder.toString(), Long.class);
 
+    if (groupId != null) {
+      query.setParameter("groupId", groupId);
+      countQuery.setParameter("groupId", groupId);
+    }
     if (nickname != null) {
       query.setParameter("nickname", "%" + nickname + "%");
       countQuery.setParameter("nickname", "%" + nickname + "%");

--- a/src/main/java/com/slide_todo/slide_todoApp/service/goal/AdminGoalService.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/service/goal/AdminGoalService.java
@@ -13,7 +13,7 @@ public interface AdminGoalService {
       String nickname, String title, String createdAfter, String createdBefore);
 
   /*어드민 페이지에서 그룹 목표 리스트 조회*/
-  ResponseDTO<GroupGoalAdminDTO> getGroupGoalsByAdmin(long page, long limit, String groupName,
+  ResponseDTO<GroupGoalAdminDTO> getGroupGoalsByAdmin(Long groupId, long page, long limit, String groupName,
       String nickname, String title, String createdAfter, String createdBefore);
 
   /*개인 목표 복수 삭제*/

--- a/src/main/java/com/slide_todo/slide_todoApp/service/goal/AdminGoalServiceImpl.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/service/goal/AdminGoalServiceImpl.java
@@ -59,10 +59,10 @@ public class AdminGoalServiceImpl implements AdminGoalService {
    * @return
    */
   @Override
-  public ResponseDTO<GroupGoalAdminDTO> getGroupGoalsByAdmin(long page, long limit,
+  public ResponseDTO<GroupGoalAdminDTO> getGroupGoalsByAdmin(Long groupId, long page, long limit,
       String nickname, String groupName, String title, String createdAfter, String createdBefore) {
 
-    GroupGoalAdminDTO result = searchGroupGoals(page, limit, nickname, groupName, title,
+    GroupGoalAdminDTO result = searchGroupGoals(groupId, page, limit, nickname, groupName, title,
         createdAfter, createdBefore);
 
     return new ResponseDTO<>(result, Responses.OK);
@@ -187,7 +187,7 @@ public class AdminGoalServiceImpl implements AdminGoalService {
   }
 
   /*그룹 목표 리스트 조회*/
-  private GroupGoalAdminDTO searchGroupGoals(long page, long limit,
+  private GroupGoalAdminDTO searchGroupGoals(Long groupId, long page, long limit,
       String nickname, String groupName, String title, String createdAfter, String createdBefore) {
     long start;
     if (limit != 0) {
@@ -213,7 +213,7 @@ public class AdminGoalServiceImpl implements AdminGoalService {
     }
 
     GroupGoalSearchResultDTO searchResult = goalRepository.findGroupGoalByAdmin(
-        nickname, groupName, title, parsedCreatedAfter, parsedCreatedBefore, start, limit
+        groupId, nickname, groupName, title, parsedCreatedAfter, parsedCreatedBefore, start, limit
     );
 
     long totalCount = goalRepository.countGroupGoal();


### PR DESCRIPTION
### 이슈 번호
- [ ] #19 
### 작업한 내용
- 어드민 페이지 그룹 목표 목록 조회 API에서 그룹 별 조회 파라미터 추가