### PR TITLE
[REFACT] 멤버 탈퇴 시 로직 변경

### DIFF
--- a/src/main/java/com/slide_todo/slide_todoApp/domain/member/Member.java
+++ b/src/main/java/com/slide_todo/slide_todoApp/domain/member/Member.java
@@ -77,7 +77,13 @@ public class Member {
 
   public void deleteMember() {
     this.getIndividualGoals().forEach(IndividualGoal::deleteGoal);
-    this.getGroupMembers().forEach(GroupMember::deleteGroupMember);
+//    this.getGroupMembers().forEach(GroupMember::deleteGroupMember);
+    this.getGroupMembers().forEach(groupmember -> {
+      if (groupmember.getIsLeader().equals(true)) {
+        groupmember.getGroup().deleteGroup();
+      }
+      groupmember.deleteGroupMember();
+    });
     this.updatedAt = LocalDateTime.now();
     this.isDeleted = true;
   }


### PR DESCRIPTION
### 이슈 번호
- [ ] 
### 작업한 내용
- 그룹 리더인 회원이 서비스 탈퇴 시 해당 그룹도 삭제되도록 로직 변경 